### PR TITLE
fixes a bug with array url param

### DIFF
--- a/src/cake/app/plugins/request_log/controllers/components/request_loggable.php
+++ b/src/cake/app/plugins/request_log/controllers/components/request_loggable.php
@@ -165,7 +165,7 @@ class RequestLoggableComponent extends Object
 	{
 		if ($exit)
 		{
-			$this->set('redirected', $url);
+			this->set('redirected', Router::url($url));
 			$this->log();
 		}
 	}


### PR DESCRIPTION
Em alguns casos a url estava chegando como array no RequestLog, e estava dando erro no insert. Achei melhor garantir com o Router::url
