### PR TITLE
Stamping script

### DIFF
--- a/src/scripts/update_stamps.sh
+++ b/src/scripts/update_stamps.sh
@@ -1,20 +1,59 @@
 #!/bin/bash
 
-command -v git > /dev/null 2>&1
-if [ $? -eq 0 ]; then
-	rootDir=$(git rev-parse --show-toplevel 2>/dev/null)
-	if [ -d "$rootDir" ]; then
-		cd "$rootDir/src/cake/app/views/layouts"
+function stampfile () {
+	found=$(grep -E "cachestamp_[0-9]+" "$1")
+	filename=$(basename "$1")
+	if [ -z "$found" ]; then
+		echo "File $filename doesn't need update"
+	else
+		sed -i -r 's/(.*)(cachestamp_)([0-9]+)(.*)/echo "\1\2$((\3+1))\4"/ge' "$1"
+		echo "File $filename updated"
 	fi
-elif [ -d "src" ]; then
-	cd "src/cake/app/views/layouts"
-elif [ -d "app" ]; then
-	cd "app/views/layouts"
-else
-	exit 1
-fi
+}
 
-for file in *.ctp; do
-	echo "Updating file $file..."
-	sed -i -r 's/(.*)stamp_([0-9]+)(.*)/echo "\1stamp_$((\2+1))\3"/ge' "$file"
-done
+function stampdir () {
+	echo -n "Searching files in '$1'... "
+	files=$(find "$1" -maxdepth 1 -type f -name \*.ctp)
+	if [ -z "$files" ]; then
+		echo "Nothing found!"
+	else
+		echo
+		for file in $files; do
+			echo -n " "
+			stampfile "$file"
+		done
+	fi
+}
+
+if [ ! $# -eq 0 ]; then
+	while [ $# -gt 0 ]; do
+		echo
+		if [ -d "$1" ]; then
+			stampdir "$1"
+		elif [ -f "$1" ]; then
+			stampfile "$1"
+		else
+			echo "Error: '$1' is not accessible"
+		fi
+		shift
+	done
+else
+	command -v git > /dev/null 2>&1
+	dir=""
+	if [ $? -eq 0 ]; then
+		rootDir=$(git rev-parse --show-toplevel 2>/dev/null)
+		if [ -d "$rootDir" ]; then
+			dir="$rootDir/src/cake/app/views/layouts"
+		fi
+	elif [ -d "src" ]; then
+		dir="src/cake/app/views/layouts"
+	elif [ -d "app" ]; then
+		dir="app/views/layouts"
+	else
+		exit 1
+	fi
+
+	if [ ! -z "$dir" ]; then
+		stampdir "$dir"
+	fi
+fi


### PR DESCRIPTION
Um novo script shell para auxiliar no problema de cache nos clientes durante o depoly de atualizações.

Para utilizá-lo, é necessário ter arquivos preparados para a atualização. Um exemplo de preparação seria:

``` php
echo $this->Decorator->css(array(
        'scheme' => $layout_scheme,
        '?' => 'cachestamp_4'
    )
);
echo $this->Html->script('prototype.js?cachestamp_1');
```

Tendo o arquivo preparado basta invocar o script, de qualquer local, indicando quais são os arquivos que precisam ser atualizados. Diretórios são aceitos também e serão vasculhados (não recursivamente) por todos os arquivos `.ctp` dentro dele. Se nenhum arquivo ou diretório for indicado, o script usará a pasta de layouts padrão do Jodel (`APP/views/layouts/`).

``` bash
$ ./update_stamps.sh
```

ou

``` bash
$ cd src/cake/app
$ ../../scripts/update_stamps.sh \
    views/layouts \
    plugins/meu_plugin/views/layouts \
    plugins/meu_plugin/views/elements
```
